### PR TITLE
fixed cucumber tests to work with Mongoid 3.

### DIFF
--- a/features/step_definitions/user_steps.rb
+++ b/features/step_definitions/user_steps.rb
@@ -6,7 +6,7 @@ def create_visitor
 end
 
 def find_user
-  @user ||= User.first conditions: {:email => @visitor[:email]}
+  @user ||= User.where(:email => @visitor[:email]).first
 end
 
 def create_unconfirmed_user
@@ -23,7 +23,7 @@ def create_user
 end
 
 def delete_user
-  @user ||= User.first conditions: {:email => @visitor[:email]}
+  @user ||= User.where(:email => @visitor[:email]).first
   @user.destroy unless @user.nil?
 end
 


### PR DESCRIPTION
`cucumber` test where failing because `Model.first` no longer takes 
arguments in Mongoid 3.

updated those calls in `user_steps.rb` to use `Model.where` for the
same behavior.

see:
-   http://mongoid.org/en/mongoid/docs/upgrading.html
-   https://github.com/mongoid/mongoid/issues/1342
